### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4.1.6
+        uses: actions/checkout@v4.1.7
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3.1.0
+        uses: docker/login-action@v3.2.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -29,7 +29,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.3.0
 
       - name: Build and push Docker image to GHCR
-        uses: docker/build-push-action@v5.3.0
+        uses: docker/build-push-action@v6.0.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.6
+      - uses: actions/checkout@v4.1.7
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.GHCR_PAT }}

--- a/app/src/global-options/parameters.tsx
+++ b/app/src/global-options/parameters.tsx
@@ -130,7 +130,7 @@ export const parameterOptions: OptionGroup = {
         type: "slider",
         label: "Temperature: " + value.toFixed(1),
         min: 0,
-        max: 1,
+        max: 2,
         step: 0.1,
         description: context.intl.formatMessage({
           defaultMessage:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.0.0](https://github.com/docker/build-push-action/releases/tag/v6.0.0)** on 2024-06-17T09:43:22Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.2.0](https://github.com/docker/login-action/releases/tag/v3.2.0)** on 2024-05-28T08:07:54Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
