### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,7 +29,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.6.1
 
       - name: Build and push Docker image to GHCR
-        uses: docker/build-push-action@v6.5.0
+        uses: docker/build-push-action@v6.7.0
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.7.0](https://github.com/docker/build-push-action/releases/tag/v6.7.0)** on 2024-08-13T12:37:53Z
