### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.0
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3.3.0
@@ -29,7 +29,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.6.1
 
       - name: Build and push Docker image to GHCR
-        uses: docker/build-push-action@v6.7.0
+        uses: docker/build-push-action@v6.8.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.GHCR_PAT }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.8.0](https://github.com/docker/build-push-action/releases/tag/v6.8.0)** on 2024-09-27T12:01:33Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.0](https://github.com/actions/checkout/releases/tag/v4.2.0)** on 2024-09-25T17:52:55Z
