### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4.2.0
+        uses: actions/checkout@v4.2.1
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3.3.0
@@ -26,7 +26,7 @@ jobs:
         uses: docker/setup-qemu-action@v3.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.6.1
+        uses: docker/setup-buildx-action@v3.7.1
 
       - name: Build and push Docker image to GHCR
         uses: docker/build-push-action@v6.9.0

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.2.0
+      - uses: actions/checkout@v4.2.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.GHCR_PAT }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.1](https://github.com/actions/checkout/releases/tag/v4.2.1)** on 2024-10-07T16:44:53Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.7.1](https://github.com/docker/setup-buildx-action/releases/tag/v3.7.1)** on 2024-10-04T07:44:26Z
